### PR TITLE
Headshot = kill shot / no revive

### DIFF
--- a/addons/far_revive/FAR_HandleDamage_EH.sqf
+++ b/addons/far_revive/FAR_HandleDamage_EH.sqf
@@ -62,28 +62,31 @@ if (UNCONSCIOUS(_unit)) then
 		};
 	};
 	
-	_oldDamage = if (_selection == "") then { damage _unit } else { _unit getHit _selection };
+	//if (_selection != "?") then
+	//{
+		_oldDamage = if (_selection == "") then { damage _unit } else { _unit getHit _selection };
 
-	if (!isNil "_oldDamage") then
-	{
-		// Apply part of the damage without multiplier when below the stabilization threshold of 50% damage
-		if (STABILIZED(_unit) && {_criticalHit && FAR_DamageMultiplier < 1}) then
+		if (!isNil "_oldDamage") then
 		{
-			_oldDamage = _damage min 0.5;
+			// Apply part of the damage without multiplier when below the stabilization threshold of 50% damage
+			if (STABILIZED(_unit) && {_criticalHit && FAR_DamageMultiplier < 1}) then
+			{
+				_oldDamage = _damage min 0.5;
+			};
+
+			_damage = ((_damage - _oldDamage) * FAR_DamageMultiplier) + _oldDamage;
+
+			if (_criticalHit) then
+			{
+				_unit setDamage _damage;
+			};
 		};
 
-		_damage = ((_damage - _oldDamage) * FAR_DamageMultiplier) + _oldDamage;
-
-		if (_criticalHit) then
+		if (_damage >= 1 && _criticalHit) then
 		{
-			_unit setDamage _damage;
+			diag_log format ["KILLED by [%1] with [%2]", _source, _ammo];
 		};
-	};
-
-	if (_damage >= 1 && _criticalHit) then
-	{
-		diag_log format ["KILLED by [%1] with [%2]", _source, _ammo];
-	};
+	//};
 }
 else
 {

--- a/addons/far_revive/FAR_HandleDamage_EH.sqf
+++ b/addons/far_revive/FAR_HandleDamage_EH.sqf
@@ -29,31 +29,61 @@ if (((_fatalHit && !isNull _source) || (_criticalHit && UNCONSCIOUS(_unit))) && 
 
 if (UNCONSCIOUS(_unit)) then
 {
-	//if (_selection != "?") then
-	//{
-		_oldDamage = if (_selection == "") then { damage _unit } else { _unit getHit _selection };
-
-		if (!isNil "_oldDamage") then
-		{
-			// Apply part of the damage without multiplier when below the stabilization threshold of 50% damage
-			if (STABILIZED(_unit) && {_criticalHit && FAR_DamageMultiplier < 1}) then
+	//Headshot - tries to confirm result of injury was from headshot
+	if(!FAR_NoHeadshot && alive _unit)then{
+		if(_selection == "head") then{
+			_killer = _unit call FAR_findKiller;
+			if((_ammo splitString "_" select 0) == "B" && _damage >= 1 && isPlayer _killer)then{
+				//Player was headshot from a player with a bullet projectile
+				FAR_NoHeadshot = false;
+				_unit setFatigue 0;
+				_unit enableFatigue false;
+				[_unit, _killer] spawn
+				{
+					_unit = _this select 0;
+					_killer = _this select 1;
+					_names = [toArray name _unit];
+					if (!isNull _killer && { (_killer != _unit) && (vehicle _killer != vehicle _unit)}) then
+					{
+						_names set [1, toArray name _killer];
+					};
+					FAR_headshotMessage = [_names, netId _unit, netId _killer];
+					publicVariable "FAR_headshotMessage";
+					["FAR_headshotMessage", FAR_headshotMessage] call FAR_public_EH;
+					_unit setDamage 1;
+				};
+			}
+			else
 			{
-				_oldDamage = _damage min 0.5;
-			};
-
-			_damage = ((_damage - _oldDamage) * FAR_DamageMultiplier) + _oldDamage;
-
-			if (_criticalHit) then
-			{
-				_unit setDamage _damage;
+				//Player was not headshot
+				_unit allowDamage false;
+				FAR_NoHeadshot = true;
 			};
 		};
+	};
+	
+	_oldDamage = if (_selection == "") then { damage _unit } else { _unit getHit _selection };
 
-		if (_damage >= 1 && _criticalHit) then
+	if (!isNil "_oldDamage") then
+	{
+		// Apply part of the damage without multiplier when below the stabilization threshold of 50% damage
+		if (STABILIZED(_unit) && {_criticalHit && FAR_DamageMultiplier < 1}) then
 		{
-			diag_log format ["KILLED by [%1] with [%2]", _source, _ammo];
+			_oldDamage = _damage min 0.5;
 		};
-	//};
+
+		_damage = ((_damage - _oldDamage) * FAR_DamageMultiplier) + _oldDamage;
+
+		if (_criticalHit) then
+		{
+			_unit setDamage _damage;
+		};
+	};
+
+	if (_damage >= 1 && _criticalHit) then
+	{
+		diag_log format ["KILLED by [%1] with [%2]", _source, _ammo];
+	};
 }
 else
 {
@@ -63,7 +93,8 @@ else
 		_unit setVariable ["FAR_isUnconscious", 1, true];
 		[] spawn fn_deletePlayerData;
 
-		_unit allowDamage false;
+		//_unit allowDamage false;
+		FAR_NoHeadshot = false;
 		//if (vehicle _unit == _unit) then { [_unit, "AinjPpneMstpSnonWrflDnon"] call switchMoveGlobal };
 		_unit enableFatigue true;
 		_unit setFatigue 1;

--- a/addons/far_revive/FAR_revive_funcs.sqf
+++ b/addons/far_revive/FAR_revive_funcs.sqf
@@ -233,6 +233,23 @@ FAR_public_EH =
 			};
 		};
 	};
+	
+	// FAR_headshotMessage
+	if (_EH == "FAR_headshotMessage") then
+	{
+		_names = _value select 0;
+		_unitName = _names select 0;
+		_killerName = _names param [1, nil];
+		_unit = objectFromNetId (_value select 1);
+		_killer = objectFromNetId (_value select 2);
+		switch (true) do
+		{
+			case (isNil "_killerName"): { systemChat format ["%1 was headshot", toString _unitName]; };
+			default {
+			systemChat format ["%1 was headshot by %2", toString _unitName, toString _killerName];
+			};
+		};
+	};
 }
 call mf_compile;
 

--- a/addons/far_revive/FAR_revive_init.sqf
+++ b/addons/far_revive/FAR_revive_init.sqf
@@ -18,7 +18,9 @@ call compile preprocessFile "addons\far_revive\FAR_revive_funcs.sqf";
 FAR_isDragging = false;
 FAR_isDragging_EH = [];
 FAR_deathMessage = [];
+FAR_headshotMessage = [];
 FAR_Debugging = false;
+FAR_NoHeadshot = false;
 
 FAR_Reset_Unit =
 {
@@ -28,6 +30,7 @@ FAR_Reset_Unit =
 	_this setVariable ["FAR_draggedBy", nil, true];
 	_this setVariable ["FAR_treatedBy", nil, true];
 	_this setCaptive false;
+	FAR_NoHeadshot = false;
 
 	if (isPlayer _this) then
 	{
@@ -106,6 +109,7 @@ FAR_findKiller = "addons\far_revive\FAR_findKiller.sqf" call mf_compile;
 ////////////////////////////////////////////////
 "FAR_isDragging_EH" addPublicVariableEventHandler FAR_public_EH;
 "FAR_deathMessage" addPublicVariableEventHandler FAR_public_EH;
+"FAR_headshotMessage" addPublicVariableEventHandler FAR_public_EH;
 
 ////////////////////////////////////////////////
 // Player Initialization


### PR DESCRIPTION
The same damage handler that puts you into revive state will check if the first instance of damage to the head is great enough to kill (>1), and then will execute full death and display a global message of 'Player was headshot by Killer'. Headshot kill only counts if it's a bullet from a player. I recommend isolated testing before adding to the mission. I've done locally PvP testing on my end and works well. But there are many factors/bugs I maybe hadn't thought of. 
