### PR TITLE
Reduce heli damage from missile

### DIFF
--- a/server/functions/vehicleHandleDamage.sqf
+++ b/server/functions/vehicleHandleDamage.sqf
@@ -8,7 +8,7 @@
 #define PLANE_COLLISION_DMG_SCALE 0.5
 #define WHEEL_COLLISION_DMG_SCALE 0.05
 #define MRAP_MISSILE_DMG_SCALE 4.0 // Temporary fix for http://feedback.arma3.com/view.php?id=21743
-#define HELI_MISSILE_DMG_SCALE 5.0
+#define HELI_MISSILE_DMG_SCALE 1.5
 #define PLANE_MISSILE_DMG_SCALE 1.5
 #define IFV_DMG_SCALE 1.5
 #define TANK_DMG_SCALE 2.0


### PR DESCRIPTION
Small helicopters will still be destroyed, but heavier heli should only be disabled from missile hit. Related to a forum post that it was too easy for heli's to be destroyed. I think the latest Arma update increased heli resistance to missiles, which messed with our original scale factor, and made every heli blow up with just 1 missile.
