### PR TITLE
Let empty vehicle array store to couchDb

### DIFF
--- a/persistence/players/sFunctions.sqf
+++ b/persistence/players/sFunctions.sqf
@@ -274,7 +274,7 @@ p_getPlayerParking = {
   };} forEach _parked_vehicles;
 
 
-  if (count(_vehicles) == 0) exitWith {};
+  //if (count(_vehicles) == 0) exitWith {};
 
 
   (_vehicles call sock_hash)


### PR DESCRIPTION
Removing this line allows an empty array to pass to the db instead of a null (which apparently wasn't being stored at all, and would never clear the last garage vehicle).
