### PR TITLE
Set max group count

### DIFF
--- a/client/systems/groups/inviteToGroup.sqf
+++ b/client/systems/groups/inviteToGroup.sqf
@@ -27,6 +27,20 @@ _hasInvite = false;
 
 diag_log "Invite to group: Before the checks";
 
+#define MAX_GROUP_COUNT 6
+_groupCount = count units player;
+if (_groupCount < MAX_GROUP_COUNT) then
+{
+	{
+		_senderUID = _x select 0;
+		if ({getPlayerUID _x == _senderUID} count units player > 0) then
+		{
+			_groupCount = _groupCount + 1;
+		};
+	} forEach currentInvites;
+};
+if (_groupCount >= MAX_GROUP_COUNT) exitWith { [format ["You cannot have more than %1 group members, including pending invites.", MAX_GROUP_COUNT]] spawn BIS_fnc_guiMessage };
+
 //Checks
 if(isNil "_target") exitWith {player globalChat "you must select someone to invite first"};
 if(_target == player) exitWith {player globalChat "you can't invite yourself"};


### PR DESCRIPTION
Agent's code from last year to limit group size.
http://forums.a3wasteland.com/index.php?topic=1917.0

Recent forums have indicated 10+ Indie groups steamrolling all players. A group limit should help keep things fair.
