### PR TITLE
Add option to dim icons, turn tags on by default

### DIFF
--- a/client/clientEvents/onKeyPress.sqf
+++ b/client/clientEvents/onKeyPress.sqf
@@ -37,6 +37,7 @@ switch (true) do
 	case (_key in A3W_customKeys_playerNames):
 	{
 		showPlayerNames = if (isNil "showPlayerNames") then { true } else { !showPlayerNames };
+		brightPlayerIcons = if (isNil "brightPlayerIcons") then { true } else { !brightPlayerIcons };
 	};
 
 	// Earplugs - End Key

--- a/client/clientEvents/onKeyRelease.sqf
+++ b/client/clientEvents/onKeyRelease.sqf
@@ -17,7 +17,8 @@ _handled = false;
 // Left & Right Windows keys
 if (_key in [219,220]) then
 {
-	showPlayerNames = false;
+	showPlayerNames = true;
+	brightPlayerIcons = true;
 };
 */
 

--- a/client/functions/drawPlayerIcons.sqf
+++ b/client/functions/drawPlayerIcons.sqf
@@ -15,7 +15,8 @@ if (!hasInterface) exitWith {};
 #define UNIT_POS(UNIT) (UNIT modelToWorldVisual [0, 0, 1.25]) // Torso height
 #define UAV_UNIT_POS(UNIT) (((vehicle UNIT) modelToWorldVisual [0, 0, 0]) vectorAdd [0, 0, 0.5])
 
-if (isNil "showPlayerNames") then { showPlayerNames = false };
+if (isNil "showPlayerNames") then { showPlayerNames = true };
+if (isNil "brightPlayerIcons") then { brightPlayerIcons = true };
 
 hudPlayerIcon_uiScale = (0.55 / (getResolution select 5)) * ICON_sizeScale; // 0.55 = Interface size "Small"
 drawPlayerIcons_array = [];
@@ -74,7 +75,7 @@ drawPlayerIcons_thread = [] spawn
 						_isUavUnit = (_simulation == "UAVPilot");
 						if (_isUavUnit && {_unit != (crew vehicle _unit) select 0}) exitWith {}; // only one AI per UAV
 
-						_alpha = (ICON_limitDistance - _dist) / (ICON_limitDistance - ICON_fadeDistance);
+						_alpha = if (brightPlayerIcons) then {(ICON_limitDistance - _dist) / (ICON_limitDistance - ICON_fadeDistance)} else {.2};
 						_color = [1,1,1,_alpha];
 						_icon = _teamIcon;
 						_size = 0;


### PR DESCRIPTION
The tags under player icons are now on by default.

Windows key will turn them off and change the icon opacity to 20%.
