### PR TITLE
exception to team balance

### DIFF
--- a/client/functions/teamBalance.sqf
+++ b/client/functions/teamBalance.sqf
@@ -8,7 +8,9 @@ if (playerSide in [BLUFOR,OPFOR] && _teamBal > 0) then{
 	_justPlayers = allPlayers - entities "HeadlessClient_F";
 	_serverCount = count _justPlayers;
 	_sideCount = playerSide countSide _justPlayers;
-	if (_serverCount >= 10 && (_sideCount > (_teamBal/100) * _serverCount)) then{
+	_opposingSide = [BLUFOR, OPFOR] select (playerSide==BLUFOR);
+	_opposingCount = _opposingSide countSide _justPlayers;
+	if (_serverCount >= 10 && (_sideCount > (_teamBal/100) * _serverCount) && (abs (_sideCount-_opposingCount)) > 3 ) then{
 		if !(_uid call isAdmin) then {
 			_prevSide = [pvar_teamSwitchList, _uid] call fn_getFromPairs;
 			if(!isNil "_prevSide")then{

--- a/server/default_config.sqf
+++ b/server/default_config.sqf
@@ -23,7 +23,7 @@ A3W_spawnBeaconSpawnHeight = 1500; // Altitude in meters at which players will s
 A3W_maxSpawnBeacons = 2;		   // Maxmimum number of spawn beacons (0 = disabled)
 A3W_uavControl = "group";          // Restrict connection to UAVs based on ownership ("owner", "group", "side")
 A3W_disableUavFeed = 0;            // Force disable UAV PIP feed to prevent thermal camera abuse (0 = no, 1 = yes)
-A3W_teamBalance = 40;              // Max percentage of players allowed on Opfor/Blufor from total server population (0 = off)
+A3W_teamBalance = 40;              // Max percentage of players allowed on Opfor/Blufor from total server population (0 = off) Bluefor/opfor can only exceed this limit if both grow in similar size.
 
 // Store settings
 A3W_showGunStoreStatus = 1;        // Show enemy and friendly presence at gunstores on map (0 = no, 1 = yes)


### PR DESCRIPTION
Allow a team (Bluefor/Opfor) to exceed the team balance limit only if
the opposing team is of similar size. It's fair to let opfor or bluefor
grow as large as they want only if the other team matches in size. (with
a difference of 3)
