### PR TITLE
add SLAM mines to AI missions

### DIFF
--- a/client/systems/scoreboard/loadScoreboard.sqf
+++ b/client/systems/scoreboard/loadScoreboard.sqf
@@ -228,14 +228,16 @@ _code =
 
 				_teamName = if (_isGroup) then
 				{
-					format ["%1's group", name leader _team]
+					_teamCnt = count units _team;
+					format ["%1's group - ( %2 )", name leader _team, _teamCnt]
 				}
 				else
 				{
+					_teamCnt = _team countSide _allPlayers;
 					switch (_team) do
 					{
-						case BLUFOR: { "BLUFOR" };
-						case OPFOR:  { "OPFOR" };
+						case BLUFOR: { format ["BLUFOR - ( %1 )", _teamCnt] };
+						case OPFOR:  { format ["OPFOR - ( %1 )", _teamCnt] };
 						default      { "Aliens" };
 					};
 				};

--- a/server/functions/serverCompile.sqf
+++ b/server/functions/serverCompile.sqf
@@ -35,8 +35,9 @@ removeDisabledMissions = [_path, "removeDisabledMissions.sqf"] call mf_compile;
 setLocationObjects = [_path, "setLocationObjects.sqf"] call mf_compile;
 setLocationState = [_path, "setLocationState.sqf"] call mf_compile;
 setMissionState = [_path, "setMissionState.sqf"] call mf_compile;
-createsniperGroup = [_path, "createUnits\sniperGroup.sqf"] call mf_compile; 
+createsniperGroup = [_path, "createUnits\sniperGroup.sqf"] call mf_compile;
 createCustomGroup3 = [_path, "createUnits\customGroup3.sqf"] call mf_compile;
+addDefensiveMines = [_path, "createUnits\addDefensiveMines.sqf"] call mf_compile;
 
 //Function Compiles
 _path = "server\functions";

--- a/server/missions/factoryMethods/createUnits/addDefensiveMines.sqf
+++ b/server/missions/factoryMethods/createUnits/addDefensiveMines.sqf
@@ -1,0 +1,26 @@
+//	@file Name: addDefensiveMines.sqf
+//	@file Author: Tyler
+//  Add defense SLAM mine perimeter for vehicle protection of AI ground soldiers
+
+private ["_missionPos"];
+_missionPos = _this select 0;
+
+_defMines = [];
+_nbMines = 60;
+_maxRadius = 80;
+_nbRings = 4;
+_mineGap = 0;
+for "_i" from 1 to _nbRings do {
+  _mineGap = _mineGap + ((_i*(_maxRadius/_nbRings))*2)*pi;
+};
+_mineGap = _mineGap/_nbMines;
+for "_i" from 1 to _nbRings do {
+  _distance = _i*(_maxRadius/_nbRings);
+  _mineCnt = ceil (((_distance*2)*pi) / _mineGap);
+  for "_i" from 1 to _mineCnt do {
+     _deg = (360/_mineCnt)*_i;
+     _minePos = _missionPos vectorAdd ([[_distance, 0, 0], _deg] call BIS_fnc_rotateVector2D);
+     _mine = createMine ["SLAMDirectionalMine", _minePos, [], 0];
+     _defMines pushBack _mine;
+  };
+};

--- a/server/missions/factoryMethods/createUnits/customGroup.sqf
+++ b/server/missions/factoryMethods/createUnits/customGroup.sqf
@@ -37,7 +37,7 @@ grenadier_loadout =  {
   _unit addItem "NVGoggles";
   _unit assignItem "NVGoggles";
 };
-  
+
 support_loadout = {
   private["_unit"];
   _unit = _this;
@@ -58,7 +58,7 @@ support_loadout = {
 sniper_loadout = {
   private["_unit"];
   _unit = _this;
-  
+
   _unit addUniform "U_I_GhillieSuit";
   _unit addBackpack "B_AssaultPack_rgr";
   _unit addMagazine "30Rnd_65x39_caseless_mag";
@@ -75,7 +75,7 @@ sniper_loadout = {
   _unit addItem "ItemGps";
   _unit assignItem "ItemGps";
   _unit addItem "ItemCompass";
-  _unit assignItem "ItemCompass";  
+  _unit assignItem "ItemCompass";
   _unit addItem "NVGoggles";
   _unit assignItem "NVGoggles";
 };
@@ -83,7 +83,7 @@ sniper_loadout = {
 aa_loadout = {
   private["_unit"];
   _unit = _this;
-  
+
   _unit addUniform "U_IG_Guerilla1_1";
   _unit addMagazine "30Rnd_9x21_Mag";
   _unit addMagazine "30Rnd_9x21_Mag";
@@ -124,7 +124,7 @@ at_loadout = {
 leader_loadout = {
   private["_unit"];
   _unit = _this;
-  
+
   _unit addUniform "U_IG_leader";
   _unit addMagazine "30Rnd_65x39_caseless_green_mag_Tracer";
   _unit addMagazine "30Rnd_65x39_caseless_green_mag_Tracer";
@@ -148,7 +148,7 @@ leader_loadout = {
 rifleman_loadout = {
   private["_unit"];
   _unit = _this;
-  
+
   _unit addUniform "U_IG_Guerilla2_3";
   _unit addMagazine "30Rnd_65x39_caseless_mag_Tracer";
   _unit addBackpack "B_AssaultPack_rgr";
@@ -161,7 +161,7 @@ rifleman_loadout = {
   _unit enablegunlights "forceOn";
 };
 
-weighted_list = 
+weighted_list =
 [
   [0.5, sniper_loadout],
   [1, aa_loadout],
@@ -170,11 +170,11 @@ weighted_list =
   [0.8, rifleman_loadout],
   [1, grenadier_loadout]
 ];
-  
+
 get_weighted_loadout = {
   private["_items"];
   _items = weighted_list;
-  
+
   //calculate the total weight
   private["_totalSum", "_weight"];
   _totalSum = 0;
@@ -182,20 +182,20 @@ get_weighted_loadout = {
     _weight = _x select 0;
     _totalSum = _weight + _totalSum;
   } forEach _items;
-  
+
   //pick at random from the distribution
   private["_index", "_i", "_item", "_sum"];
   _index = random _totalSum;
   _sum = 0;
   _i = 0;
-  
+
   while {_sum < _index} do {
     _item = _items select _i;
     _weight = _item select 0;
     _sum = _sum + _weight;
     _i = _i + 1;
   };
-  
+
   ((_items select (_i - 1)) select 1)
 };
 
@@ -215,22 +215,24 @@ for "_i" from 1 to _nbUnits do
 
   _unit addVest "V_PlateCarrier1_rgr";
   _unit addItem "FirstAidKit";
-  
+
   if (_unit == leader _group) then {
     _unit call leader_loadout;
     _unit setRank "SERGEANT";
   }
-  else {  
+  else {
     private["_loadout"];
     _loadout = call get_weighted_loadout;
     _unit call _loadout;
   };
-	
+
   _unit addRating 1e11;
   _unit spawn addMilCap;
   _unit spawn refillPrimaryAmmo;
   _unit call setMissionSkill;
   _unit addEventHandler ["Killed", server_playerDied];
 };
+
+[_pos] call addDefensiveMines;
 
 [_group, _pos] call defendArea;

--- a/server/missions/factoryMethods/createUnits/customGroup3.sqf
+++ b/server/missions/factoryMethods/createUnits/customGroup3.sqf
@@ -28,7 +28,7 @@ for "_i" from 1 to _nbUnits do
 	_uPos = _pos vectorAdd ([[random _radius, random _radius, 0], random 360] call BIS_fnc_rotateVector2D);
 	_unit = _group createUnit [_unitTypes call BIS_fnc_selectRandom, _uPos, [], 0, "Form"];
 	_unit setPosATL _uPos;
-	
+
 	removeAllWeapons _unit;
 	removeAllAssignedItems _unit;
 	removeUniform _unit;
@@ -121,5 +121,7 @@ for "_i" from 1 to _nbUnits do
 	_unit call setMissionSkill;
 	_unit addEventHandler ["Killed", server_playerDied];
 };
+
+[_pos] call addDefensiveMines;
 
 [_group, _pos, "LandVehicle"] call defendArea;

--- a/server/missions/factoryMethods/createUnits/sniperGroup.sqf
+++ b/server/missions/factoryMethods/createUnits/sniperGroup.sqf
@@ -180,4 +180,6 @@ _leader = leader _group;
 	_x addEventHandler ["Killed", server_playerDied];
 } forEach units _group;
 
+[_pos] call addDefensiveMines;
+
 [_group, _pos] call defendArea;

--- a/server/missions/missionProcessor.sqf
+++ b/server/missions/missionProcessor.sqf
@@ -9,7 +9,7 @@ if (!isServer) exitwith {};
 #define MISSION_LOCATION_COOLDOWN (10*60)
 #define MISSION_TIMER_EXTENSION (15*60)
 
-private ["_controllerSuffix", "_missionTimeout", "_availableLocations", "_missionLocation", "_leader", "_marker", "_failed", "_complete", "_startTime", "_oldAiCount", "_leaderTemp", "_newAiCount", "_adjustTime", "_lastPos", "_floorHeight"];
+private ["_controllerSuffix", "_missionTimeout", "_availableLocations", "_missionLocation", "_leader", "_marker", "_failed", "_complete", "_startTime", "_oldAiCount", "_leaderTemp", "_newAiCount", "_adjustTime", "_lastPos", "_floorHeight", "_defMines"];
 
 // Variables that can be defined in the mission script :
 private ["_missionType", "_locationsArray", "_aiGroup", "_missionPos", "_missionPicture", "_missionHintText", "_successHintMessage", "_failedHintMessage"];
@@ -114,7 +114,8 @@ if (_failed) then
 	// Mission failed
 
 	{ moveOut _x; deleteVehicle _x } forEach units _aiGroup;
-
+	if (!isNil "_defMines") then { { deleteVehicle _x; } forEach _defMines };
+	
 	if (!isNil "_failedExec") then { call _failedExec };
 
 	if (!isNil "_vehicle" && {typeName _vehicle == "OBJECT"}) then
@@ -157,6 +158,7 @@ else
 		_floorHeight = (getPos _leader) select 2;
 		_lastPos set [2, (_lastPos select 2) - _floorHeight];
 	};
+	if (!isNil "_defMines") then { { deleteVehicle _x; } forEach _defMines };
 
 	if (!isNil "_successExec") then { call _successExec };
 


### PR DESCRIPTION
Add SLAM mines to AI missions with stationary ground troops, for vehicle
defense. Too easy to just run over all the AI to complete a mission.
